### PR TITLE
fix datetime minus bug

### DIFF
--- a/src/datetime.cpp
+++ b/src/datetime.cpp
@@ -539,6 +539,17 @@ namespace jed_utils
 			hours = mdt.get_hour() - odt.get_hour();
 			seconds = mdt.get_second() - odt.get_second();
 			minutes = mdt.get_minute() - odt.get_minute();
+			if (seconds < 0) {
+				seconds += 60;
+				minutes--;
+			}
+			if (minutes < 0) {
+				minutes += 60;
+				hours--;
+			}
+			if (hours < 0) {
+				hours += 24;
+			}
 		}
 		else {
 			if (mdt.get_second() > odt.get_second()) {

--- a/test/datetime_unittest/datetime_unittest.cpp
+++ b/test/datetime_unittest/datetime_unittest.cpp
@@ -1039,6 +1039,18 @@ TEST(datetime_operator_minus, Difference0Days7Hours23Mins7Secs_ReturnOK)
 	assert(ts1.get_seconds() == 7);
 }
 
+TEST(datetime_operator_minus, Difference2Days17Hours1Mins58Secs_ReturnOK)
+{
+	datetime date1 = datetime(2023, 2, 27, 15, 58, 2);
+	datetime date2 = datetime(2023, 3, 2, 9, 0, 0);
+	timespan ts1 = date2 - date1;
+	assert(ts1.get_days() == 2);
+	assert(ts1.get_hours() == 17);
+	assert(ts1.get_minutes() == 1);
+	assert(ts1.get_seconds() == 58);
+	assert(ts1.get_total_seconds() == 61318 + 3600 * 24 * 2);
+}
+
 TEST(datetime_static_is_leapyear, Year2000_ReturnTrue)
 {
 	ASSERT_TRUE(datetime::is_leapyear(2000));


### PR DESCRIPTION
When dt_a minus dt_b, if dt_a is greater than dt_b, and the hour of dt_a is less than the hour of dt_b, in the previous code, the hour of span will be a negative value.

Here are some tests that can reproduce the bug:
```C++
datetime date1 = datetime(2023, 2, 27, 15, 58, 2);
datetime date2 = datetime(2023, 3, 2, 9, 0, 0);
timespan ts1 = date2 - date1;
assert(ts1.get_days() == 2);
assert(ts1.get_hours() == 17);
assert(ts1.get_minutes() == 1);
assert(ts1.get_seconds() == 58);
assert(ts1.get_total_seconds() == 61318 + 3600 * 24 * 2);
```
I fixed this bug and added the situation to the test file.